### PR TITLE
[BE] docker-compose 터미널 제어권 관련 버그 수정

### DIFF
--- a/backend/docker/docker-start.sh
+++ b/backend/docker/docker-start.sh
@@ -13,8 +13,4 @@ docker rm $REDIS
 
 docker rmi pyrodb:1.0
 
-docker-compose up --build
-
-docker-compose up -d
-
-exit 0
+docker-compose up --build -d

--- a/backend/server/.gitignore
+++ b/backend/server/.gitignore
@@ -1,3 +1,4 @@
+*.txt
 nohup.out
 HELP.md
 .gradle

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -4,4 +4,6 @@ sh ./docker-start.sh
 
 cd ../server
 
+sleep 5
+
 sh ./run.sh


### PR DESCRIPTION
터미널 제어권 반환 문제 떄문에 start.sh 가 제대로 실행되지 않던 버그를 수정했습니다.

`be/27/redis` 브랜치로 가셔서, `sh ./starth.sh` 가 잘 실행되는지 확인 부탁드립니다.